### PR TITLE
FIXED: wrapper expansion #100

### DIFF
--- a/src/core/functions_common.sh
+++ b/src/core/functions_common.sh
@@ -708,7 +708,9 @@ argument_processing()
           add_program "${key}"
         else
           # There is a wrapper corresponding with this key, so we add each program that is in the wrapper.
-          add_programs "${set_of_features}"
+          for feature_keyname in ${set_of_features}; do
+            add_programs "${feature_keyname}"
+          done
         fi
       ;;
     esac


### PR DESCRIPTION
Implemented a for in order to call `add_programs`with a single keyname and append each feature to the installation from the supplied wrapper